### PR TITLE
Make type of options required for `set` partial

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -165,7 +165,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async setAll(newOptions: TOptions): Promise<void> {
+	async setAll(newOptions: Partial<TOptions>): Promise<void> {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.set({
 				[this.storageName]: newOptions


### PR DESCRIPTION
From https://github.com/bfred-it/webext-options-sync/commit/fc77d661742e95ecefce66d0b738c1e3a7d7aae3#r34067329.

Fixes [Travis build](https://travis-ci.org/sindresorhus/refined-github/jobs/550317445#L319) over at https://github.com/sindresorhus/refined-github/pull/2146.